### PR TITLE
Error replies

### DIFF
--- a/tests/rusoto.rs
+++ b/tests/rusoto.rs
@@ -1,8 +1,8 @@
 use rusoto_core::Region;
 use rusoto_logs::{
     CloudWatchLogs, CloudWatchLogsClient, CreateLogGroupRequest, CreateLogStreamRequest,
-    DescribeLogGroupsRequest, DescribeLogStreamsRequest, GetLogEventsRequest, InputLogEvent,
-    LogGroup, PutLogEventsRequest,
+    DescribeLogGroupsRequest, DescribeLogStreamsRequest, DescribeLogStreamsError,
+    GetLogEventsRequest, InputLogEvent, LogGroup, PutLogEventsRequest,
 };
 use std::default::Default;
 
@@ -105,6 +105,26 @@ fn stream_found() {
     let stream_name = stream.log_stream_name.unwrap();
 
     assert_eq!(stream_name, "test-log-stream".to_string());
+}
+
+#[test]
+fn stream_failure() {
+    let addr = start_server();
+    let client = client(addr);
+
+    let desc_streams_req = DescribeLogStreamsRequest {
+        log_group_name: "ServiceUnavailable".into(),
+        ..Default::default()
+    };
+
+    let res = client
+        .describe_log_streams(desc_streams_req)
+        .sync()
+        .unwrap_err();
+    match res {
+      DescribeLogStreamsError::ServiceUnavailable(_) => (),
+      x => panic!("{:?}", x)
+    }
 }
 
 #[test]


### PR DESCRIPTION
In order to address https://github.com/timberio/vector/issues/624, I need to be able to simulate errors from CWL. Since this project emulate CWL at socket level, we need some sort of convention to ask mockwatchlog to return error replies. We could:

1. add a custom API (outside of the `rusoto_logs::CloudwatchLogs` triat) which would be used to configure the response, or
1. add known strings which always trigger error responses, 

While 1. would be more explicit, it would also require the consuming tests to use a "raw" HTTP client or perhaps make use of a special mockwatchlogs client. I have therefore opted for 2., specifically the convention that there is one string parameter in the API (in the implemented example, `log_group_name`) that is checked against a list of strings representing known error replies.

This PR implements this convention for the `describe_log_streams` in order to show what it would look like. If this style is acceptable, I'll extend it to all implemented API calls.

It is also worth noting that Rusoto has changed the way errors are encoded in the API so that this project will have to be updated to use the latest version. It may be useful to do that before adding this feature?